### PR TITLE
Updated library.json to include addition of Kwikset HALO-01, Google Topaz-2.7, Google KR1 and Acurite Tower 06002RM

### DIFF
--- a/custom_components/battery_notes/data/library.json
+++ b/custom_components/battery_notes/data/library.json
@@ -41,6 +41,16 @@
             "battery_quantity": 4
         },
         {
+            "manufacturer": "Google",
+            "model": "KR1",
+            "battery_type": "CR2"
+        },        {
+            "manufacturer": "Google",
+            "model": "Topaz-2.7",
+            "battery_type": "AA"
+            "battery_quantity": 3
+        },
+        {
             "manufacturer": "HEIMAN",
             "model": "Smart carbon monoxide sensor (HS1CA-E)",
             "battery_type": "CR123A"
@@ -95,6 +105,12 @@
             "model": "TRADFRI shortcut button (E1812)",
             "battery_type": "CR2032"
         },
+        {
+            "manufacturer": "Kwikset",
+            "model": "HALO-01",
+            "battery_type": "AA",
+            "battery_quantity": 4
+        },   
         {
             "manufacturer": "Lidl",
             "model": "Silvercrest radiator valve with thermostat (368308_2010)",
@@ -152,6 +168,12 @@
             "manufacturer": "Philips",
             "model": "Hue wall switch module (929003017102)",
             "battery_type": "CR2450"
+        },
+        {
+            "manufacturer": "rtl_433",
+            "model": "Acurite-Tower",
+            "battery_type": "AA",
+            "battery_quantity": 2
         },
         {
             "manufacturer": "Saswell",


### PR DESCRIPTION
Updated library to include the following:
* Kwikset HALO-01 smart Door locks (4 x AA)
* Google Topaz-2.7 Nest Protect wired model (3 x AA Energizer Ultimate Lithium “L91”)
* Google KR1 Nest Temperature Sensor (1 x CR2 Lithium)
* rtl_433 Acurite Tower (2 x AA) (This is an AcuRite 06002RM Wireless Temperature and Humidity Sensor connected to HA via RTL_433)